### PR TITLE
Fix table in _results template

### DIFF
--- a/templates/_results.ace
+++ b/templates/_results.ace
@@ -12,8 +12,8 @@ div.row
       {{range $i, $val := .}}
         tr data-toggle="collapse" data-target="#change-{{$i}}"
           td {{Timestamp .ChangeSet.Timestamp}}
-          td {{.ChangeSet.Checksum}}
           td <a href={{URL "read"}}/{{.Id}}>{{.Id}}</a>
+          td {{.ChangeSet.Checksum}}
           td {{.Author}}
           td {{.Comment}}
           tr id="change-{{$i}}" class=collapse


### PR DESCRIPTION
There's a mismatch between the table's header cell and the data cells.
(checksum and ID were switched)